### PR TITLE
Refactors error handling and disables vet check

### DIFF
--- a/setagaya/.golangci.yml
+++ b/setagaya/.golangci.yml
@@ -103,6 +103,8 @@ linters:
 
     govet:
       enable-all: true
+      disable:
+        - fieldalignment  # Disable field alignment warnings (cosmetic, low impact)
 
     gocyclo:
       min-complexity: 15

--- a/setagaya/api/collection.go
+++ b/setagaya/api/collection.go
@@ -37,9 +37,9 @@ func (s *SetagayaAPI) collectionConfigGetHandler(w http.ResponseWriter, req *htt
 		return
 	}
 	for _, ep := range eps {
-		plan, err := model.GetPlan(ep.PlanID)
-		if err != nil {
-			s.handleErrors(w, err)
+		plan, planErr := model.GetPlan(ep.PlanID)
+		if planErr != nil {
+			s.handleErrors(w, planErr)
 			return
 		}
 		ep.Name = plan.Name

--- a/setagaya/api/main.go
+++ b/setagaya/api/main.go
@@ -353,7 +353,7 @@ func (s *SetagayaAPI) planFilesUploadHandler(w http.ResponseWriter, r *http.Requ
 		s.handleErrors(w, err)
 		return
 	}
-	if err := r.ParseMultipartForm(100 << 20); err != nil { //parse 100 MB of data
+	if parseErr := r.ParseMultipartForm(100 << 20); parseErr != nil { //parse 100 MB of data
 		s.handleErrors(w, makeInvalidRequestError("failed to parse multipart form"))
 		return
 	}
@@ -387,7 +387,7 @@ func (s *SetagayaAPI) collectionFilesUploadHandler(w http.ResponseWriter, r *htt
 		s.handleErrors(w, err)
 		return
 	}
-	if err := r.ParseMultipartForm(100 << 20); err != nil { //parse 100 MB of data
+	if parseErr := r.ParseMultipartForm(100 << 20); parseErr != nil { //parse 100 MB of data
 		s.handleErrors(w, makeInvalidRequestError("failed to parse multipart form"))
 		return
 	}
@@ -412,7 +412,7 @@ func (s *SetagayaAPI) collectionFilesDeleteHandler(w http.ResponseWriter, r *htt
 		s.handleErrors(w, err)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
+	if parseErr := r.ParseForm(); parseErr != nil {
 		s.handleErrors(w, makeInvalidRequestError("failed to parse form"))
 		return
 	}
@@ -437,7 +437,7 @@ func (s *SetagayaAPI) planFilesDeleteHandler(w http.ResponseWriter, r *http.Requ
 		s.handleErrors(w, err)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
+	if parseErr := r.ParseForm(); parseErr != nil {
 		s.handleErrors(w, makeInvalidRequestError("failed to parse form"))
 		return
 	}
@@ -569,7 +569,7 @@ func (s *SetagayaAPI) collectionUploadHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	e := new(model.ExecutionWrapper)
-	if err := r.ParseMultipartForm(1 << 20); err != nil { //parse 1 MB of data
+	if parseErr := r.ParseMultipartForm(1 << 20); parseErr != nil { //parse 1 MB of data
 		s.handleErrors(w, makeInvalidRequestError("form"))
 		return
 	}
@@ -600,14 +600,14 @@ func (s *SetagayaAPI) collectionUploadHandler(w http.ResponseWriter, r *http.Req
 	}
 	totalEnginesRequired := 0
 	for _, ep := range e.Content.Tests {
-		plan, err := model.GetPlan(ep.PlanID)
-		if err != nil {
-			s.handleErrors(w, err)
+		plan, planErr := model.GetPlan(ep.PlanID)
+		if planErr != nil {
+			s.handleErrors(w, planErr)
 			return
 		}
-		planProject, err := model.GetProject(plan.ProjectID)
-		if err != nil {
-			s.handleErrors(w, err)
+		planProject, projectErr := model.GetProject(plan.ProjectID)
+		if projectErr != nil {
+			s.handleErrors(w, projectErr)
 			return
 		}
 		if project.ID != planProject.ID {
@@ -638,9 +638,9 @@ func (s *SetagayaAPI) collectionUploadHandler(w http.ResponseWriter, r *http.Req
 		}
 	}
 	if s.ctr.Scheduler.PodReadyCount(collection.ID) > 0 {
-		currentPlans, err := collection.GetExecutionPlans()
-		if err != nil {
-			s.handleErrors(w, err)
+		currentPlans, plansErr := collection.GetExecutionPlans()
+		if plansErr != nil {
+			s.handleErrors(w, plansErr)
 			return
 		}
 		if ok, message := hasInvalidDiff(currentPlans, e.Content.Tests); ok {

--- a/setagaya/controller/collection.go
+++ b/setagaya/controller/collection.go
@@ -57,8 +57,8 @@ func (c *Controller) TermAndPurgeCollection(collection *model.Collection) (err e
 			err = e
 		}
 	}()
-	if err := c.TermCollection(collection, true); err != nil {
-		return err
+	if termErr := c.TermCollection(collection, true); termErr != nil {
+		return termErr
 	}
 	if err = c.Scheduler.PurgeCollection(collection.ID); err != nil {
 		return err
@@ -85,9 +85,9 @@ func (c *Controller) TriggerCollection(collection *model.Collection) error {
 	}
 	engineDataConfigs := prepareCollection(collection)
 	for _, ep := range collection.ExecutionPlans {
-		plan, err := model.GetPlan(ep.PlanID)
-		if err != nil {
-			return err
+		plan, planErr := model.GetPlan(ep.PlanID)
+		if planErr != nil {
+			return planErr
 		}
 		if plan.TestFile == nil {
 			return fmt.Errorf("triggering plan aborted; there is no Test file (.jmx) in this plan %d", plan.ID)

--- a/setagaya/controller/garbage.go
+++ b/setagaya/controller/garbage.go
@@ -22,8 +22,8 @@ func (c *Controller) CheckRunningThenTerminate() {
 					collection := j.collection
 					currRunID, err := collection.GetCurrentRun()
 					if currRunID != int64(0) {
-						if err := pc.term(false, &c.connectedEngines); err != nil {
-							log.Printf("Error terminating plan %d: %v", j.ep.PlanID, err)
+						if termErr := pc.term(false, &c.connectedEngines); termErr != nil {
+							log.Printf("Error terminating plan %d: %v", j.ep.PlanID, termErr)
 						}
 						log.Printf("Plan %d is terminated.", j.ep.PlanID)
 					}

--- a/setagaya/controller/main.go
+++ b/setagaya/controller/main.go
@@ -201,11 +201,11 @@ func (c *Controller) DeployCollection(collection *model.Collection) error {
 		vu += e.Engines * e.Concurrency
 	}
 	sid := ""
-	if project, err := model.GetProject(collection.ProjectID); err == nil {
+	if project, projectErr := model.GetProject(collection.ProjectID); projectErr == nil {
 		sid = project.SID
 	}
-	if err := collection.NewLaunchEntry(sid, config.SC.Context, int64(enginesCount), nodesCount, int64(vu)); err != nil {
-		return err
+	if launchErr := collection.NewLaunchEntry(sid, config.SC.Context, int64(enginesCount), nodesCount, int64(vu)); launchErr != nil {
+		return launchErr
 	}
 	err = utils.Retry(func() error {
 		return c.Scheduler.ExposeProject(collection.ProjectID)

--- a/setagaya/controller/prometheus.go
+++ b/setagaya/controller/prometheus.go
@@ -4,10 +4,11 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/hveda/Setagaya/setagaya/config"
-	"github.com/hveda/Setagaya/setagaya/model"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/hveda/Setagaya/setagaya/config"
+	"github.com/hveda/Setagaya/setagaya/model"
 )
 
 // We use a KV map of [runID:set(values)] to store labels and statuses

--- a/setagaya/engines/model/enginedata_test.go
+++ b/setagaya/engines/model/enginedata_test.go
@@ -192,30 +192,30 @@ func TestEngineDataConfigDeepCopies(t *testing.T) {
 					t.Error("Both maps should be non-nil")
 				}
 
-			// Test that files in the copy are deep copied
-			copiedFile1 := copy.EngineData["file1.csv"]
-			copiedFile2 := copy.EngineData["file2.csv"]
+				// Test that files in the copy are deep copied
+				copiedFile1 := copy.EngineData["file1.csv"]
+				copiedFile2 := copy.EngineData["file2.csv"]
 
-			// Test that files are different objects
-			if originalFile1 == copiedFile1 {
-				t.Error("File1 should be different objects")
-			}
-			if originalFile2 == copiedFile2 {
-				t.Error("File2 should be different objects")
-			}
+				// Test that files are different objects
+				if originalFile1 == copiedFile1 {
+					t.Error("File1 should be different objects")
+				}
+				if originalFile2 == copiedFile2 {
+					t.Error("File2 should be different objects")
+				}
 
-			assert.Equal(t, originalFile1.Filename, copiedFile1.Filename)
-			assert.Equal(t, originalFile2.Filename, copiedFile2.Filename)
+				assert.Equal(t, originalFile1.Filename, copiedFile1.Filename)
+				assert.Equal(t, originalFile2.Filename, copiedFile2.Filename)
 
-			// Test that copies are independent of each other
-			for j, otherCopy := range copies {
-				if i != j {
-					// Test that copy maps are both non-nil
-					if copy.EngineData == nil || otherCopy.EngineData == nil {
-						t.Error("Both copy maps should be non-nil")
+				// Test that copies are independent of each other
+				for j, otherCopy := range copies {
+					if i != j {
+						// Test that copy maps are both non-nil
+						if copy.EngineData == nil || otherCopy.EngineData == nil {
+							t.Error("Both copy maps should be non-nil")
+						}
 					}
 				}
-			}
 			}
 		})
 	}

--- a/setagaya/model/collection.go
+++ b/setagaya/model/collection.go
@@ -250,8 +250,8 @@ outer:
 		delPending = append(delPending, cp.PlanID)
 	}
 	for _, ep := range ec.Tests {
-		if err := c.AddExecutionPlan(ep); err != nil {
-			log.Printf("Error adding execution plan: %v", err)
+		if addErr := c.AddExecutionPlan(ep); addErr != nil {
+			log.Printf("Error adding execution plan: %v", addErr)
 		}
 	}
 	//remove deleted plans
@@ -539,8 +539,8 @@ func (c *Collection) NewLaunchEntry(owner, cxt string, enginesCount, machinesCou
 		return err
 	}
 	defer func() {
-		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
-			log.Printf("Error rolling back transaction: %v", err)
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && rollbackErr != sql.ErrTxDone {
+			log.Printf("Error rolling back transaction: %v", rollbackErr)
 		}
 	}()
 	r, err := tx.Exec("insert into collection_launch (collection_id) values(?)", c.ID)
@@ -574,8 +574,8 @@ func (c *Collection) MarkUsageFinished(cxt string, vu int64) error {
 		return err
 	}
 	defer func() {
-		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
-			log.Printf("Error rolling back transaction: %v", err)
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && rollbackErr != sql.ErrTxDone {
+			log.Printf("Error rolling back transaction: %v", rollbackErr)
 		}
 	}()
 

--- a/setagaya/model/collection_test.go
+++ b/setagaya/model/collection_test.go
@@ -179,8 +179,8 @@ func TestCollectionRuns(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := c.RunFinish(runID); err != nil {
-		t.Fatal(err)
+	if finishErr := c.RunFinish(runID); finishErr != nil {
+		t.Fatal(finishErr)
 	}
 	runs, err := c.GetRuns()
 	if err != nil {
@@ -227,8 +227,8 @@ func TestCollectionRun(t *testing.T) {
 	_, err = c.StartRun()
 	assert.NotNil(t, err)
 
-	if err := c.StopRun(); err != nil {
-		t.Fatal(err)
+	if stopErr := c.StopRun(); stopErr != nil {
+		t.Fatal(stopErr)
 	}
 	runID, err = c.GetCurrentRun()
 	assert.NoError(t, err)

--- a/setagaya/model/errors_test.go
+++ b/setagaya/model/errors_test.go
@@ -82,6 +82,7 @@ func TestDBErrorUnwrap(t *testing.T) {
 	// While DBError doesn't implement Unwrap, we can still access the original error
 	assert.Equal(t, originalErr, dbErr.Err)
 	assert.Contains(t, dbErr.Err.Error(), "connection timeout")
+	assert.Equal(t, "database timeout", dbErr.Message) // Test that the message is set correctly
 }
 
 func TestDBErrorComparison(t *testing.T) {

--- a/setagaya/model/execution_test.go
+++ b/setagaya/model/execution_test.go
@@ -272,6 +272,10 @@ func TestExecutionStructsEdgeCases(t *testing.T) {
 			CSVSplit:     false,
 		}
 		assert.Equal(t, 0, len(ec.Tests))
+		assert.Equal(t, "empty-collection", ec.Name)
+		assert.Equal(t, int64(123), ec.ProjectID)
+		assert.Equal(t, int64(456), ec.CollectionID)
+		assert.False(t, ec.CSVSplit)
 	})
 
 	t.Run("negative values in execution plan", func(t *testing.T) {
@@ -284,10 +288,13 @@ func TestExecutionStructsEdgeCases(t *testing.T) {
 			Duration:    -300,
 			CSVSplit:    false,
 		}
-		// Struct should accept negative values even if they're not logical
+		assert.Equal(t, "negative-test", ep.Name)
 		assert.Equal(t, int64(-1), ep.PlanID)
 		assert.Equal(t, -5, ep.Concurrency)
+		assert.Equal(t, -2, ep.Rampup)
+		assert.Equal(t, -1, ep.Engines)
 		assert.Equal(t, -300, ep.Duration)
+		assert.False(t, ep.CSVSplit)
 	})
 
 	t.Run("very large values", func(t *testing.T) {
@@ -300,8 +307,13 @@ func TestExecutionStructsEdgeCases(t *testing.T) {
 			Duration:    2147483647,
 			CSVSplit:    true,
 		}
+		assert.Equal(t, "large-test", ep.Name)
 		assert.Equal(t, int64(9223372036854775807), ep.PlanID)
 		assert.Equal(t, 2147483647, ep.Concurrency)
+		assert.Equal(t, 2147483647, ep.Rampup)
+		assert.Equal(t, 2147483647, ep.Engines)
+		assert.Equal(t, 2147483647, ep.Duration)
+		assert.True(t, ep.CSVSplit)
 	})
 }
 

--- a/setagaya/model/user.go
+++ b/setagaya/model/user.go
@@ -3,9 +3,10 @@ package model
 import (
 	"net/http"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/hveda/Setagaya/setagaya/auth"
 	"github.com/hveda/Setagaya/setagaya/config"
-	log "github.com/sirupsen/logrus"
 )
 
 type Account struct {

--- a/setagaya/object_storage/storage_gcp.go
+++ b/setagaya/object_storage/storage_gcp.go
@@ -54,10 +54,10 @@ func newStorageClient(ctx context.Context) *storage.Client {
 	}
 	if config.SC.ObjectStorage.RequireProxy {
 		log.Info("Setting up GCP storage client with proxy")
-		baseTransportWithProxy, err := htransport.NewTransport(ctx, config.SC.HTTPProxyClient.Transport,
+		baseTransportWithProxy, transportErr := htransport.NewTransport(ctx, config.SC.HTTPProxyClient.Transport,
 			option.WithCredentials(creds))
-		if err != nil {
-			log.Fatal(err)
+		if transportErr != nil {
+			log.Fatal(transportErr)
 		}
 		if transport, ok := hc.Transport.(*oauth2.Transport); ok {
 			transport.Base = baseTransportWithProxy

--- a/setagaya/object_storage/storage_local.go
+++ b/setagaya/object_storage/storage_local.go
@@ -44,8 +44,8 @@ func (l localStorage) Upload(filename string, content io.ReadCloser) error {
 	if _, err = io.Copy(fw, content); err != nil {
 		return err
 	}
-	if err := w.Close(); err != nil {
-		return err
+	if closeErr := w.Close(); closeErr != nil {
+		return closeErr
 	}
 
 	url := l.GetUrl(filename)


### PR DESCRIPTION
Improves error handling by consistently using specific error variable names.

Disables the `fieldalignment` vet check in `.golangci.yml` due to its cosmetic nature and low impact.